### PR TITLE
feat: add JDBC configuration and query loading infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/
 .kotlin
 
 ### IntelliJ IDEA ###
+/src/main/resources/config.yml
+.editorconfig
+gradle.properties
 AGENTS.md
 docs/
 .idea/

--- a/src/main/java/com/potenup/lxp/common/jdbc/DatabaseConfig.java
+++ b/src/main/java/com/potenup/lxp/common/jdbc/DatabaseConfig.java
@@ -1,0 +1,102 @@
+package com.potenup.lxp.common.jdbc;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DatabaseConfig {
+	private final String url;
+	private final String username;
+	private final String password;
+
+	public DatabaseConfig(String url, String username, String password) {
+		this.url = requireValue(url, "DB_URL");
+		this.username = requireValue(username, "DB_USERNAME");
+		this.password = requireValue(password, "DB_PASSWORD");
+	}
+
+	public static DatabaseConfig fromEnvironment() {
+		return new DatabaseConfig(
+			read("db.url", "DB_URL"),
+			read("db.username", "DB_USERNAME"),
+			read("db.password", "DB_PASSWORD")
+		);
+	}
+
+	public static DatabaseConfig fromResource(String resourcePath) {
+		Map<String, String> values = loadYamlLikeConfig(resourcePath);
+
+		return new DatabaseConfig(
+			values.get("db.url"),
+			values.get("db.username"),
+			values.get("db.password")
+		);
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	private static Map<String, String> loadYamlLikeConfig(String resourcePath) {
+		try (InputStream inputStream = getResourceAsStream(resourcePath);
+		     BufferedReader reader = new BufferedReader(
+				     new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+			Map<String, String> values = new HashMap<>();
+			String line;
+
+			while ((line = reader.readLine()) != null) {
+				String trimmedLine = line.trim();
+				if (trimmedLine.isEmpty() || trimmedLine.startsWith("#")) {
+					continue;
+				}
+
+				int separatorIndex = trimmedLine.indexOf(':');
+				if (separatorIndex < 0) {
+					continue;
+				}
+
+				String key = trimmedLine.substring(0, separatorIndex).trim();
+				String value = trimmedLine.substring(separatorIndex + 1).trim();
+				values.put(key, value);
+			}
+			return values;
+		} catch (IOException exception) {
+			throw new IllegalStateException("Failed to load config resource: " + resourcePath, exception);
+		}
+	}
+
+	private static InputStream getResourceAsStream(String resourcePath) {
+		InputStream inputStream = DatabaseConfig.class.getResourceAsStream(resourcePath);
+		if (inputStream == null) {
+			throw new IllegalStateException("Config resource not found: " + resourcePath);
+		}
+		return inputStream;
+	}
+
+	private static String read(String propertyName, String envName) {
+		String propertyValue = System.getProperty(propertyName);
+		if (propertyValue != null && !propertyValue.isBlank()) {
+			return propertyValue;
+		}
+		return System.getenv(envName);
+	}
+
+	private String requireValue(String value, String keyName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalStateException(keyName + " must be configured.");
+		}
+		return value;
+	}
+}

--- a/src/main/java/com/potenup/lxp/common/jdbc/JdbcConnectionManager.java
+++ b/src/main/java/com/potenup/lxp/common/jdbc/JdbcConnectionManager.java
@@ -1,0 +1,21 @@
+package com.potenup.lxp.common.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class JdbcConnectionManager {
+	private final DatabaseConfig properties;
+
+	public JdbcConnectionManager(DatabaseConfig properties) {
+		this.properties = properties;
+	}
+
+	public Connection getConnection() throws SQLException {
+		return DriverManager.getConnection(
+			properties.getUrl(),
+			properties.getUsername(),
+			properties.getPassword()
+		);
+	}
+}

--- a/src/main/java/com/potenup/lxp/common/query/QueryRegistry.java
+++ b/src/main/java/com/potenup/lxp/common/query/QueryRegistry.java
@@ -1,0 +1,51 @@
+package com.potenup.lxp.common.query;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class QueryRegistry {
+    private final Map<String, String> queries;
+
+    private QueryRegistry(Map<String, String> queries) {
+        this.queries = queries;
+    }
+
+    public static QueryRegistry fromXmlResource(String resourcePath) {
+        try (InputStream inputStream = QueryRegistry.class.getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("Query resource not found: " + resourcePath);
+            }
+
+            Document document = DocumentBuilderFactory.newInstance()
+                    .newDocumentBuilder()
+                    .parse(inputStream);
+            NodeList queryNodes = document.getElementsByTagName("query");
+            Map<String, String> queries = new HashMap<>();
+
+            for (int index = 0; index < queryNodes.getLength(); index++) {
+                Element element = (Element) queryNodes.item(index);
+                String queryId = element.getAttribute("id");
+                String sql = element.getTextContent().trim();
+                queries.put(queryId, sql);
+            }
+
+            return new QueryRegistry(queries);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to load query resource: " + resourcePath, exception);
+        }
+    }
+
+    public String get(String queryId) {
+        String query = queries.get(queryId);
+        if (query == null || query.isBlank()) {
+            throw new IllegalStateException("Query not found: " + queryId);
+        }
+        return query;
+    }
+}

--- a/src/main/java/com/potenup/lxp/common/query/QueryRegistry.java
+++ b/src/main/java/com/potenup/lxp/common/query/QueryRegistry.java
@@ -3,49 +3,82 @@ package com.potenup.lxp.common.query;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
 public class QueryRegistry {
-    private final Map<String, String> queries;
+	private static final String QUERY_TAG = "query";
+	private static final String QUERY_ID_ATTRIBUTE = "id";
+	// XMLConstants에 없는 구현체별 feature는 상수로 캡슐화합니다.
+	private final Map<String, String> queries;
+	private static final String DISALLOW_DOCTYPE_DECL =
+			"http://apache.org/xml/features/disallow-doctype-decl";
 
-    private QueryRegistry(Map<String, String> queries) {
-        this.queries = queries;
-    }
+	private QueryRegistry(Map<String, String> queries) {
+		this.queries = Map.copyOf(queries);
+	}
 
-    public static QueryRegistry fromXmlResource(String resourcePath) {
-        try (InputStream inputStream = QueryRegistry.class.getResourceAsStream(resourcePath)) {
-            if (inputStream == null) {
-                throw new IllegalStateException("Query resource not found: " + resourcePath);
-            }
+	public static QueryRegistry fromXmlResource(String resourcePath) {
+		try (InputStream inputStream = QueryRegistry.class.getResourceAsStream(resourcePath)) {
+			if (inputStream == null) {
+				throw new IllegalStateException("Query resource not found: " + resourcePath);
+			}
 
-            Document document = DocumentBuilderFactory.newInstance()
-                    .newDocumentBuilder()
-                    .parse(inputStream);
-            NodeList queryNodes = document.getElementsByTagName("query");
-            Map<String, String> queries = new HashMap<>();
+			DocumentBuilderFactory factory = createSecureFactory();
+			Document document = factory.newDocumentBuilder().parse(inputStream);
+			NodeList queryNodes = document.getElementsByTagName(QUERY_TAG);
+			Map<String, String> queries = new HashMap<>();
 
-            for (int index = 0; index < queryNodes.getLength(); index++) {
-                Element element = (Element) queryNodes.item(index);
-                String queryId = element.getAttribute("id");
-                String sql = element.getTextContent().trim();
-                queries.put(queryId, sql);
-            }
+			for (int index = 0; index < queryNodes.getLength(); index++) {
+				Element element = (Element) queryNodes.item(index);
+				String queryId = element.getAttribute(QUERY_ID_ATTRIBUTE);
+				String sql = element.getTextContent().trim();
 
-            return new QueryRegistry(queries);
-        } catch (Exception exception) {
-            throw new IllegalStateException("Failed to load query resource: " + resourcePath, exception);
-        }
-    }
+				if (queryId.isBlank()) {
+					throw new IllegalStateException("Query id must not be blank: " + resourcePath);
+				}
+				if (sql.isBlank()) {
+					throw new IllegalStateException("Query sql must not be blank: " + queryId);
+				}
+				if (queries.containsKey(queryId)) {
+					throw new IllegalStateException("Duplicate query id: " + queryId);
+				}
 
-    public String get(String queryId) {
-        String query = queries.get(queryId);
-        if (query == null || query.isBlank()) {
-            throw new IllegalStateException("Query not found: " + queryId);
-        }
-        return query;
-    }
+				queries.put(queryId, sql);
+			}
+
+			return new QueryRegistry(queries);
+		} catch (ParserConfigurationException | SAXException | IOException exception) {
+			throw new IllegalStateException("Failed to load query resource: " + resourcePath, exception);
+		}
+	}
+
+	private static DocumentBuilderFactory createSecureFactory() throws ParserConfigurationException {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		factory.setXIncludeAware(false);
+		factory.setExpandEntityReferences(false);
+
+		return factory;
+	}
+
+	public String get(String queryId) {
+		String query = queries.get(queryId);
+		if (query == null) {
+			throw new IllegalStateException("Query not found: " + queryId);
+		}
+		return query;
+	}
 }

--- a/src/main/resources/config.yml.template
+++ b/src/main/resources/config.yml.template
@@ -1,0 +1,3 @@
+db.url: jdbc:mysql://localhost:3306/WANTED_LMS
+db.username: {your_username}
+db.password: {your_password}

--- a/src/main/resources/queries.xml
+++ b/src/main/resources/queries.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<queries>
+    <query id="instructor.insert"><![CDATA[
+        INSERT INTO instructor (name, introduction)
+        VALUES (?, ?)
+    ]]></query>
+
+    <query id="instructor.existsById"><![CDATA[
+        SELECT 1
+        FROM instructor
+        WHERE id = ?
+    ]]></query>
+
+    <query id="instructor.findAll"><![CDATA[
+        SELECT id, name, introduction
+        FROM instructor
+        ORDER BY id ASC
+    ]]></query>
+
+    <query id="instructor.findById"><![CDATA[
+        SELECT id, name, introduction
+        FROM instructor
+        WHERE id = ?
+    ]]></query>
+
+    <query id="instructor.update"><![CDATA[
+        UPDATE instructor
+        SET name = ?, introduction = ?
+        WHERE id = ?
+    ]]></query>
+
+    <query id="instructor.deleteById"><![CDATA[
+        DELETE FROM instructor
+        WHERE id = ?
+    ]]></query>
+
+    <query id="course.insert"><![CDATA[
+        INSERT INTO course (title, description, price, level, instructor_id)
+        VALUES (?, ?, ?, ?, ?)
+    ]]></query>
+
+    <query id="course.existsById"><![CDATA[
+        SELECT 1
+        FROM course
+        WHERE id = ?
+    ]]></query>
+
+    <query id="content.insert"><![CDATA[
+        INSERT INTO content (title, content_type, content, seq, course_id)
+        VALUES (?, ?, ?, ?, ?)
+    ]]></query>
+</queries>

--- a/src/test/java/com/potenup/lxp/common/jdbc/DatabaseConfigTest.java
+++ b/src/test/java/com/potenup/lxp/common/jdbc/DatabaseConfigTest.java
@@ -1,0 +1,16 @@
+package com.potenup.lxp.common.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DatabaseConfigTest {
+	@Test
+	void fromResourceReadsDatabaseValuesFromConfigFile() {
+		DatabaseConfig databaseConfig = DatabaseConfig.fromResource("/config.yml");
+
+		assertEquals("jdbc:mysql://localhost:3306/WANTED_LMS", databaseConfig.getUrl());
+		assertEquals("park", databaseConfig.getUsername());
+		assertEquals("park", databaseConfig.getPassword());
+	}
+}

--- a/src/test/java/com/potenup/lxp/common/query/QueryRegistryTest.java
+++ b/src/test/java/com/potenup/lxp/common/query/QueryRegistryTest.java
@@ -1,0 +1,15 @@
+package com.potenup.lxp.common.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueryRegistryTest {
+    @Test
+    void fromXmlResourceLoadsInstructorQueries() {
+        QueryRegistry queryRegistry = QueryRegistry.fromXmlResource("/queries.xml");
+
+        assertTrue(queryRegistry.get("instructor.insert").contains("INSERT INTO instructor"));
+        assertTrue(queryRegistry.get("instructor.existsById").contains("FROM instructor"));
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #


## 📌 개요
- JDBC 기반 기능 구현을 위한 공통 인프라를 추가했습니다.
- DB 설정 로딩과 XML 쿼리 로딩 구조를 먼저 구성했습니다.

## ✨ 변경 사항
- `DatabaseConfig` 추가
- `JdbcConnectionManager` 추가
- `QueryRegistry` 추가
- `queries.xml` 리소스 추가
- 공통 설정/쿼리 로딩 테스트 추가

## 🔥 변경 이유
- 이후 구현할 도메인별 JDBC Repository 구현에서 공통적으로 사용할 DB 연결 및 SQL 로딩 기반이 필요했습니다.
- SQL과 설정을 코드에서 분리해 관리하기 위한 초기 인프라를 구성했습니다.

## 🧪 테스트
- [x] `.\gradlew.bat test` 실행

## 🤔 고민한 부분
- SQL 리소스는 xml파일을 생성하여 외부화하고 애플리케이션 코드에서는 QueryRegistry를 통해 접근하도록 구성했습니다.
- DB 설정은 실행 시 리소스 파일에서 읽도록 구성했으며 실제 민감 정보 파일(yml)은 이번 PR 범위에서 제외했습니다.

## ✅ 체크리스트
- [x] 불필요한 코드/로그 제거
- [x] 테스트 코드 추가 또는 수정
- [ ] 문서 업데이트 (필요 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 데이터베이스 연결 구성 및 JDBC 연결 생성 기능 추가
  * 외부 XML 리소스에서 SQL 쿼리를 로드해 ID로 조회하는 쿼리 레지스트리 도입
  * 강사·과정·콘텐츠 관련 기본 SQL 쿼리 세트 추가

* **테스트**
  * 구성 로드와 쿼리 레지스트리 동작을 검증하는 단위 테스트 추가

* **잡일(Chores)**
  * 기본 구성 템플릿과 무시 설정 갱신 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->