### PR TITLE
fix: add issue template front matter

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,11 @@
+---
+name: Feature request
+about: 새로운 기능 제안을 등록합니다
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
 ## 🚀 이슈 내용
 <!-- 어떤 기능인지 간단히 설명 -->
 - 


### PR DESCRIPTION
## 관련된 이슈
- Closes #


## 개요
- GitHub 이슈 템플릿이 정상 인식되도록 front matter를 추가했습니다.

## 변경 사항
- `.github/ISSUE_TEMPLATE/feature_request.md` 상단에 YAML front matter 추가
- `name`, `about`, `title`, `labels`, `assignees` 설정
- 이슈 생성 시 템플릿 chooser에서 노출되도록 수정

## 변경 이유(선택)
- 기존 템플릿은 본문만 있고 필수 메타데이터가 없어 GitHub 이슈 템플릿으로 적용되지 않았습니다.

## 테스트
- [ ] 로컬 테스트 완료

## 고려한 부분(선택)
- 애플리케이션 코드나 DB 설정은 변경하지 않고 템플릿 파일만 수정했습니다.

## 스크린샷 (선택)

## 체크리스트
- [ ] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [ ] 문서 업데이트 (필요 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **작업 (Chores)**
  * GitHub 기능 요청 이슈 템플릿에 메타데이터 구성을 추가하여 이슈 자동 분류 및 관리 기능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->