### PR TITLE
Feature/content exception handling

### DIFF
--- a/src/main/java/com/potenup/lxp/common/exception/ConfigurationException.java
+++ b/src/main/java/com/potenup/lxp/common/exception/ConfigurationException.java
@@ -1,0 +1,11 @@
+package com.potenup.lxp.common.exception;
+
+public class ConfigurationException extends LxpException {
+    public ConfigurationException(String message) {
+        super(message);
+    }
+
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/potenup/lxp/common/exception/ConstraintViolationException.java
+++ b/src/main/java/com/potenup/lxp/common/exception/ConstraintViolationException.java
@@ -1,0 +1,11 @@
+package com.potenup.lxp.common.exception;
+
+public class ConstraintViolationException extends LxpException {
+    public ConstraintViolationException(String message) {
+        super(message);
+    }
+
+    public ConstraintViolationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/potenup/lxp/common/exception/DataAccessException.java
+++ b/src/main/java/com/potenup/lxp/common/exception/DataAccessException.java
@@ -1,0 +1,11 @@
+package com.potenup.lxp.common.exception;
+
+public class DataAccessException extends LxpException {
+    public DataAccessException(String message) {
+        super(message);
+    }
+
+    public DataAccessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/potenup/lxp/common/exception/LxpException.java
+++ b/src/main/java/com/potenup/lxp/common/exception/LxpException.java
@@ -1,0 +1,11 @@
+package com.potenup.lxp.common.exception;
+
+public class LxpException extends RuntimeException {
+    public LxpException(String message) {
+        super(message);
+    }
+
+    public LxpException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/potenup/lxp/common/exception/NotFoundException.java
+++ b/src/main/java/com/potenup/lxp/common/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.potenup.lxp.common.exception;
+
+public class NotFoundException extends LxpException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+    public NotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/potenup/lxp/common/exception/ValidationException.java
+++ b/src/main/java/com/potenup/lxp/common/exception/ValidationException.java
@@ -1,0 +1,11 @@
+package com.potenup.lxp.common.exception;
+
+public class ValidationException extends LxpException {
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/potenup/lxp/course/cli/CourseCliHandler.java
+++ b/src/main/java/com/potenup/lxp/course/cli/CourseCliHandler.java
@@ -1,5 +1,6 @@
 package com.potenup.lxp.course.cli;
 
+import com.potenup.lxp.common.exception.LxpException;
 import com.potenup.lxp.course.controller.CourseController;
 import com.potenup.lxp.course.domain.Course;
 import com.potenup.lxp.course.domain.CourseLevel;
@@ -47,15 +48,15 @@ public class CourseCliHandler {
             String title = readLine("제목 > ");
             String description = readLine("설명 > ");
             int price = readInt("가격 > ");
-            CourseLevel level = readCourseLevel("난이도(LOW/MEDIUM/HIGH) > ");
+            CourseLevel level = readCourseLevel("레벨(LOW/MEDIUM/HIGH) > ");
             Long instructorId = readLong("강사 ID > ");
 
             try {
                 Long courseId = courseController.createCourse(
-                        new CourseCreateRequest(title, description, price, level, instructorId)
+                    new CourseCreateRequest(title, description, price, level, instructorId)
                 );
                 System.out.println("강의가 등록되었습니다. id: " + courseId);
-            } catch (IllegalArgumentException exception) {
+            } catch (LxpException exception) {
                 System.out.println(exception.getMessage());
                 continue;
             }
@@ -72,6 +73,9 @@ public class CourseCliHandler {
             }
             if (choice == 2) {
                 showListScreen();
+            } else {
+                System.out.println("잘못된 메뉴입니다.");
+                continue;
             }
             return;
         }
@@ -114,8 +118,8 @@ public class CourseCliHandler {
 
             try {
                 course = courseController.getCourse(courseId);
-            } catch (IllegalArgumentException exception) {
-                System.out.println("존재하지 않는 강의입니다.");
+            } catch (LxpException exception) {
+                System.out.println(exception.getMessage());
                 return;
             }
 
@@ -132,9 +136,13 @@ public class CourseCliHandler {
             if (choice == 1) {
                 showUpdateScreen(course);
             } else if (choice == 2) {
-                courseController.deleteCourse(courseId);
-                System.out.println("삭제가 완료되었습니다. id: " + courseId);
-                return;
+                try {
+                    courseController.deleteCourse(courseId);
+                    System.out.println("삭제가 완료되었습니다. id: " + courseId);
+                    return;
+                } catch (LxpException exception) {
+                    System.out.println(exception.getMessage());
+                }
             } else if (choice == 3) {
                 return;
             } else {
@@ -143,24 +151,26 @@ public class CourseCliHandler {
         }
     }
 
-    private void showUpdateScreen(Course course) {
+    private void showUpdateScreen(Course currentCourse) {
+        Course course = currentCourse;
         while (true) {
             printTitle("강의 수정");
-            System.out.println("빈 값 입력 시 기존 값이 유지됩니다.");
+            System.out.println("빈 값을 입력하면 기존 값이 유지됩니다.");
             String title = readLine("제목(" + course.getTitle() + ") > ");
             String description = readLine("설명(" + course.getDescription() + ") > ");
             Integer price = readOptionalInt("가격(" + course.getPrice() + ") > ");
-            CourseLevel level = readOptionalCourseLevel("난이도(" + course.getLevel() + ") > ");
+            CourseLevel level = readOptionalCourseLevel("레벨(" + course.getLevel() + ") > ");
             Long instructorId = readOptionalLong("강사 ID(" + course.getInstructorId() + ") > ");
 
             try {
                 Course updatedCourse = courseController.updateCourse(
-                        course.getId(),
-                        new CourseUpdateRequest(title, description, price, level, instructorId)
+                    course.getId(),
+                    new CourseUpdateRequest(title, description, price, level, instructorId)
                 );
                 System.out.println("수정되었습니다.");
                 printCourseDetail(updatedCourse);
-            } catch (IllegalArgumentException exception) {
+                course = updatedCourse;
+            } catch (LxpException exception) {
                 System.out.println(exception.getMessage());
                 continue;
             }
@@ -177,8 +187,13 @@ public class CourseCliHandler {
                 continue;
             }
             if (choice == 2) {
-                courseController.deleteCourse(course.getId());
-                System.out.println("삭제가 완료되었습니다. id: " + course.getId());
+                try {
+                    courseController.deleteCourse(course.getId());
+                    System.out.println("삭제가 완료되었습니다. id: " + course.getId());
+                } catch (LxpException exception) {
+                    System.out.println(exception.getMessage());
+                    continue;
+                }
             }
             return;
         }
@@ -189,7 +204,7 @@ public class CourseCliHandler {
         System.out.println("제목: " + course.getTitle());
         System.out.println("설명: " + course.getDescription());
         System.out.println("가격: " + course.getPrice());
-        System.out.println("난이도: " + course.getLevel());
+        System.out.println("레벨: " + course.getLevel());
         System.out.println("강사 id: " + course.getInstructorId());
     }
 
@@ -254,8 +269,8 @@ public class CourseCliHandler {
         while (true) {
             String value = readLine(prompt);
             try {
-                return CourseLevel.valueOf(value.toUpperCase());
-            } catch (IllegalArgumentException exception) {
+                return CourseLevel.fromInput(value);
+            } catch (LxpException exception) {
                 System.out.println("LOW, MEDIUM, HIGH 중 하나를 입력해주세요.");
             }
         }
@@ -268,8 +283,8 @@ public class CourseCliHandler {
                 return null;
             }
             try {
-                return CourseLevel.valueOf(value.toUpperCase());
-            } catch (IllegalArgumentException exception) {
+                return CourseLevel.fromInput(value);
+            } catch (LxpException exception) {
                 System.out.println("LOW, MEDIUM, HIGH 중 하나를 입력해주세요.");
             }
         }

--- a/src/main/java/com/potenup/lxp/course/domain/Course.java
+++ b/src/main/java/com/potenup/lxp/course/domain/Course.java
@@ -1,117 +1,119 @@
 package com.potenup.lxp.course.domain;
 
+import com.potenup.lxp.common.exception.ValidationException;
+
 import java.sql.Timestamp;
 
 public class Course {
-	private static final int MAX_TITLE_LENGTH = 50;
-	private static final int MAX_DESCRIPTION_LENGTH = 200;
-	private static final int MIN_PRICE = 0;
-	private static final long MIN_VALID_ID = 1L;
+    private static final int MAX_TITLE_LENGTH = 50;
+    private static final int MAX_DESCRIPTION_LENGTH = 200;
+    private static final int MIN_PRICE = 0;
+    private static final long MIN_VALID_ID = 1L;
 
-	private Long id;
-	private String title;
-	private String description;
-	private int price;
-	private Timestamp createdAt;
-	private Timestamp updatedAt;
-	private CourseLevel level;
-	private Long instructorId;
+    private Long id;
+    private String title;
+    private String description;
+    private int price;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+    private CourseLevel level;
+    private Long instructorId;
 
-	public Course(String title, String description, int price, CourseLevel level, Long instructorId) {
-		this(null, title, description, price, level, instructorId);
-	}
+    public Course(String title, String description, int price, CourseLevel level, Long instructorId) {
+        this(null, title, description, price, level, instructorId);
+    }
 
-	public Course(Long id, String title, String description, int price, CourseLevel level, Long instructorId) {
-		validateId(id);
-		validateTitle(title);
-		validateDescription(description);
-		validatePrice(price);
-		validateLevel(level);
-		validateInstructorId(instructorId);
+    public Course(Long id, String title, String description, int price, CourseLevel level, Long instructorId) {
+        validateId(id);
+        validateTitle(title);
+        validateDescription(description);
+        validatePrice(price);
+        validateLevel(level);
+        validateInstructorId(instructorId);
 
-		this.id = id;
-		this.title = title;
-		this.description = description;
-		this.price = price;
-		this.level = level;
-		this.instructorId = instructorId;
-	}
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.price = price;
+        this.level = level;
+        this.instructorId = instructorId;
+    }
 
-	public Long getId() {
-		return id;
-	}
+    public Long getId() {
+        return id;
+    }
 
-	public String getTitle() {
-		return title;
-	}
+    public String getTitle() {
+        return title;
+    }
 
-	public String getDescription() {
-		return description;
-	}
+    public String getDescription() {
+        return description;
+    }
 
-	public int getPrice() {
-		return price;
-	}
+    public int getPrice() {
+        return price;
+    }
 
-	public Timestamp getCreatedAt() {
-		return createdAt == null ? null : new Timestamp(createdAt.getTime());
-	}
+    public Timestamp getCreatedAt() {
+        return createdAt == null ? null : new Timestamp(createdAt.getTime());
+    }
 
-	public Timestamp getUpdatedAt() {
-		return updatedAt == null ? null : new Timestamp(updatedAt.getTime());
-	}
+    public Timestamp getUpdatedAt() {
+        return updatedAt == null ? null : new Timestamp(updatedAt.getTime());
+    }
 
-	public CourseLevel getLevel() {
-		return level;
-	}
+    public CourseLevel getLevel() {
+        return level;
+    }
 
-	public Long getInstructorId() {
-		return instructorId;
-	}
+    public Long getInstructorId() {
+        return instructorId;
+    }
 
-	private void validateId(Long id) {
-		if (id != null && id < MIN_VALID_ID) {
-			throw new IllegalArgumentException("Course id must be greater than zero.");
-		}
-	}
+    private void validateId(Long id) {
+        if (id != null && id < MIN_VALID_ID) {
+            throw new ValidationException("Course id must be greater than zero.");
+        }
+    }
 
-	private void validateTitle(String title) {
-		if (title == null || title.isBlank()) {
-			throw new IllegalArgumentException("Course title is required.");
-		}
-		if (title.length() > MAX_TITLE_LENGTH) {
-			throw new IllegalArgumentException(
-					"Course title must be " + MAX_TITLE_LENGTH + " characters or less."
-			);
-		}
-	}
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new ValidationException("Course title is required.");
+        }
+        if (title.length() > MAX_TITLE_LENGTH) {
+            throw new ValidationException(
+                "Course title must be " + MAX_TITLE_LENGTH + " characters or less."
+            );
+        }
+    }
 
-	private void validateDescription(String description) {
-		if (description == null || description.isBlank()) {
-			throw new IllegalArgumentException("Course description is required.");
-		}
-		if (description.length() > MAX_DESCRIPTION_LENGTH) {
-			throw new IllegalArgumentException(
-					"Course description must be " + MAX_DESCRIPTION_LENGTH + " characters or less."
-			);
-		}
-	}
+    private void validateDescription(String description) {
+        if (description == null || description.isBlank()) {
+            throw new ValidationException("Course description is required.");
+        }
+        if (description.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new ValidationException(
+                "Course description must be " + MAX_DESCRIPTION_LENGTH + " characters or less."
+            );
+        }
+    }
 
-	private void validatePrice(int price) {
-		if (price < MIN_PRICE) {
-			throw new IllegalArgumentException("Course price must be " + MIN_PRICE + " or greater.");
-		}
-	}
+    private void validatePrice(int price) {
+        if (price < MIN_PRICE) {
+            throw new ValidationException("Course price must be " + MIN_PRICE + " or greater.");
+        }
+    }
 
-	private void validateLevel(CourseLevel level) {
-		if (level == null) {
-			throw new IllegalArgumentException("Course level is required.");
-		}
-	}
+    private void validateLevel(CourseLevel level) {
+        if (level == null) {
+            throw new ValidationException("Course level is required.");
+        }
+    }
 
-	private void validateInstructorId(Long instructorId) {
-		if (instructorId == null || instructorId < MIN_VALID_ID) {
-			throw new IllegalArgumentException("Instructor id is required.");
-		}
-	}
+    private void validateInstructorId(Long instructorId) {
+        if (instructorId == null || instructorId < MIN_VALID_ID) {
+            throw new ValidationException("Instructor id is required.");
+        }
+    }
 }

--- a/src/main/java/com/potenup/lxp/course/domain/CourseLevel.java
+++ b/src/main/java/com/potenup/lxp/course/domain/CourseLevel.java
@@ -1,7 +1,20 @@
 package com.potenup.lxp.course.domain;
 
+import com.potenup.lxp.common.exception.ValidationException;
+
 public enum CourseLevel {
     LOW,
     MEDIUM,
-    HIGH
+    HIGH;
+
+    public static CourseLevel fromInput(String input) {
+        for (CourseLevel level : values()) {
+            if (level.name().equalsIgnoreCase(input)) {
+                return level;
+            }
+        }
+        throw new ValidationException(
+            "유효하지 않은 레벨입니다: " + input + " (LOW, MEDIUM, HIGH 중 입력)"
+        );
+    }
 }

--- a/src/main/java/com/potenup/lxp/course/repository/CourseRepository.java
+++ b/src/main/java/com/potenup/lxp/course/repository/CourseRepository.java
@@ -12,9 +12,9 @@ public interface CourseRepository {
 
     Optional<Course> findById(Long courseId);
 
-    void update(Course course);
+	void update(Course course);
 
-    void deleteById(Long courseId);
+    boolean deleteById(Long courseId);
 
     boolean existsById(Long courseId);
 

--- a/src/main/java/com/potenup/lxp/course/repository/JdbcCourseRepository.java
+++ b/src/main/java/com/potenup/lxp/course/repository/JdbcCourseRepository.java
@@ -1,5 +1,7 @@
 package com.potenup.lxp.course.repository;
 
+import com.potenup.lxp.common.exception.DataAccessException;
+import com.potenup.lxp.common.exception.NotFoundException;
 import com.potenup.lxp.common.jdbc.JdbcConnectionManager;
 import com.potenup.lxp.common.query.QueryRegistry;
 import com.potenup.lxp.course.domain.Course;
@@ -24,11 +26,11 @@ public class JdbcCourseRepository implements CourseRepository {
     }
 
     @Override
-	public Long save(Course course) {
-		try (Connection connection = connectionManager.getConnection();
+    public Long save(Course course) {
+        try (Connection connection = connectionManager.getConnection();
              PreparedStatement statement = connection.prepareStatement(
-                     queryRegistry.get("course.insert"),
-                     Statement.RETURN_GENERATED_KEYS
+                 queryRegistry.get("course.insert"),
+                 Statement.RETURN_GENERATED_KEYS
              )) {
             statement.setString(1, course.getTitle());
             statement.setString(2, course.getDescription());
@@ -42,9 +44,9 @@ public class JdbcCourseRepository implements CourseRepository {
                     return generatedKeys.getLong(1);
                 }
             }
-            throw new IllegalStateException("Failed to retrieve generated course id.");
+            throw new DataAccessException("Failed to retrieve generated course id.");
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to save course.", exception);
+            throw new DataAccessException("Failed to save course.", exception);
         }
     }
 
@@ -59,7 +61,7 @@ public class JdbcCourseRepository implements CourseRepository {
             }
             return courses;
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to load courses.", exception);
+            throw new DataAccessException("Failed to load courses.", exception);
         }
     }
 
@@ -76,7 +78,7 @@ public class JdbcCourseRepository implements CourseRepository {
                 return Optional.empty();
             }
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to load course.", exception);
+            throw new DataAccessException("Failed to load course.", exception);
         }
     }
 
@@ -90,21 +92,29 @@ public class JdbcCourseRepository implements CourseRepository {
             statement.setString(4, course.getLevel().name().toLowerCase());
             statement.setLong(5, course.getInstructorId());
             statement.setLong(6, course.getId());
-            statement.executeUpdate();
+
+            int affectedRows = statement.executeUpdate();
+            if (affectedRows == 0) {
+                throw new NotFoundException("No course updated for id: " + course.getId());
+            }
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to update course.", exception);
+            throw new DataAccessException("Failed to update course.", exception);
         }
     }
 
     @Override
-    public void deleteById(Long courseId) {
+    public boolean deleteById(Long courseId) {
         try (Connection connection = connectionManager.getConnection();
              PreparedStatement statement = connection.prepareStatement(queryRegistry.get("course.deleteById"))) {
             statement.setLong(1, courseId);
-            statement.executeUpdate();
+            int affectedRows = statement.executeUpdate();
+            if (affectedRows == 0) {
+                return false;
+            }
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to delete course.", exception);
+            throw new DataAccessException("Failed to delete course.", exception);
         }
+        return true;
     }
 
     @Override
@@ -117,7 +127,7 @@ public class JdbcCourseRepository implements CourseRepository {
                 return resultSet.next();
             }
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to check course existence.", exception);
+            throw new DataAccessException("Failed to check course existence.", exception);
         }
     }
 
@@ -131,18 +141,18 @@ public class JdbcCourseRepository implements CourseRepository {
                 return resultSet.next();
             }
         } catch (SQLException exception) {
-            throw new IllegalStateException("Failed to check course existence by instructor id.", exception);
+            throw new DataAccessException("Failed to check course existence by instructor id.", exception);
         }
     }
 
     private Course mapCourse(ResultSet resultSet) throws SQLException {
         return new Course(
-                resultSet.getLong("id"),
-                resultSet.getString("title"),
-                resultSet.getString("description"),
-                resultSet.getInt("price"),
-                CourseLevel.valueOf(resultSet.getString("level").toUpperCase()),
-                resultSet.getLong("instructor_id")
+            resultSet.getLong("id"),
+            resultSet.getString("title"),
+            resultSet.getString("description"),
+            resultSet.getInt("price"),
+            CourseLevel.valueOf(resultSet.getString("level").toUpperCase()),
+            resultSet.getLong("instructor_id")
         );
     }
 }

--- a/src/main/java/com/potenup/lxp/course/repository/JdbcCourseRepository.java
+++ b/src/main/java/com/potenup/lxp/course/repository/JdbcCourseRepository.java
@@ -2,6 +2,7 @@ package com.potenup.lxp.course.repository;
 
 import com.potenup.lxp.common.exception.DataAccessException;
 import com.potenup.lxp.common.exception.NotFoundException;
+import com.potenup.lxp.common.exception.ValidationException;
 import com.potenup.lxp.common.jdbc.JdbcConnectionManager;
 import com.potenup.lxp.common.query.QueryRegistry;
 import com.potenup.lxp.course.domain.Course;
@@ -151,8 +152,15 @@ public class JdbcCourseRepository implements CourseRepository {
             resultSet.getString("title"),
             resultSet.getString("description"),
             resultSet.getInt("price"),
-            CourseLevel.valueOf(resultSet.getString("level").toUpperCase()),
+			parseCourseLevel(resultSet.getString("level")),
             resultSet.getLong("instructor_id")
         );
     }
+	private CourseLevel parseCourseLevel(String level) {
+		try {
+			return CourseLevel.fromInput(level);
+		} catch (ValidationException exception) {
+			throw new DataAccessException("Invalid course level stored in database: " + level, exception);
+		}
+	}
 }

--- a/src/main/java/com/potenup/lxp/course/service/CourseService.java
+++ b/src/main/java/com/potenup/lxp/course/service/CourseService.java
@@ -1,5 +1,7 @@
 package com.potenup.lxp.course.service;
 
+import com.potenup.lxp.common.exception.NotFoundException;
+import com.potenup.lxp.common.exception.ValidationException;
 import com.potenup.lxp.course.domain.Course;
 import com.potenup.lxp.course.dto.CourseCreateRequest;
 import com.potenup.lxp.course.dto.CourseUpdateRequest;
@@ -19,15 +21,15 @@ public class CourseService {
 
     public Long createCourse(CourseCreateRequest request) {
         if (!instructorRepository.existsById(request.getInstructorId())) {
-            throw new IllegalArgumentException("강사가 존재하지 않습니다. 강사를 먼저 등록해주세요.");
+            throw new ValidationException("강사가 존재하지 않습니다. 강사를 먼저 등록해주세요.");
         }
 
         Course course = new Course(
-                request.getTitle(),
-                request.getDescription(),
-                request.getPrice(),
-                request.getLevel(),
-                request.getInstructorId()
+            request.getTitle(),
+            request.getDescription(),
+            request.getPrice(),
+            request.getLevel(),
+            request.getInstructorId()
         );
         return courseRepository.save(course);
     }
@@ -38,27 +40,27 @@ public class CourseService {
 
     public Course getCourse(Long courseId) {
         return courseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("강의를 찾을 수 없습니다."));
+            .orElseThrow(() -> new NotFoundException("강의를 찾을 수 없습니다."));
     }
 
     public Course updateCourse(Long courseId, CourseUpdateRequest request) {
         Course currentCourse = getCourse(courseId);
 
         Long updatedInstructorId = request.getInstructorId() == null
-                ? currentCourse.getInstructorId()
-                : request.getInstructorId();
+            ? currentCourse.getInstructorId()
+            : request.getInstructorId();
 
         if (!instructorRepository.existsById(updatedInstructorId)) {
-            throw new IllegalArgumentException("강사가 존재하지 않습니다. 강사를 먼저 등록해주세요.");
+            throw new ValidationException("강사가 존재하지 않습니다. 강사를 먼저 등록해주세요.");
         }
 
         Course updatedCourse = new Course(
-                currentCourse.getId(),
-                isBlank(request.getTitle()) ? currentCourse.getTitle() : request.getTitle(),
-                isBlank(request.getDescription()) ? currentCourse.getDescription() : request.getDescription(),
-                request.getPrice() == null ? currentCourse.getPrice() : request.getPrice(),
-                request.getLevel() == null ? currentCourse.getLevel() : request.getLevel(),
-                updatedInstructorId
+            currentCourse.getId(),
+            isBlank(request.getTitle()) ? currentCourse.getTitle() : request.getTitle(),
+            isBlank(request.getDescription()) ? currentCourse.getDescription() : request.getDescription(),
+            request.getPrice() == null ? currentCourse.getPrice() : request.getPrice(),
+            request.getLevel() == null ? currentCourse.getLevel() : request.getLevel(),
+            updatedInstructorId
         );
 
         courseRepository.update(updatedCourse);
@@ -66,10 +68,10 @@ public class CourseService {
     }
 
     public void deleteCourse(Long courseId) {
-        if (!courseRepository.existsById(courseId)) {
-            throw new IllegalArgumentException("강의를 찾을 수 없습니다.");
+        boolean deleted = courseRepository.deleteById(courseId);
+        if (!deleted) {
+            throw new NotFoundException("강의를 찾을 수 없습니다.");
         }
-        courseRepository.deleteById(courseId);
     }
 
     private boolean isBlank(String value) {

--- a/src/main/java/com/potenup/lxp/instructor/cli/InstructorCliHandler.java
+++ b/src/main/java/com/potenup/lxp/instructor/cli/InstructorCliHandler.java
@@ -1,5 +1,6 @@
 package com.potenup.lxp.instructor.cli;
 
+import com.potenup.lxp.common.exception.LxpException;
 import com.potenup.lxp.instructor.controller.InstructorController;
 import com.potenup.lxp.instructor.domain.Instructor;
 import com.potenup.lxp.instructor.dto.InstructorCreateRequest;
@@ -10,228 +11,226 @@ import java.util.Scanner;
 
 // 강사 관리 화면의 입력과 출력 흐름을 담당하는 CLI 핸들러다.
 public class InstructorCliHandler {
-	private final InstructorController instructorController;
-	private final Scanner scanner;
+    private final InstructorController instructorController;
+    private final Scanner scanner;
 
-	public InstructorCliHandler(InstructorController instructorController, Scanner scanner) {
-		this.instructorController = instructorController;
-		this.scanner = scanner;
-	}
+    public InstructorCliHandler(InstructorController instructorController, Scanner scanner) {
+        this.instructorController = instructorController;
+        this.scanner = scanner;
+    }
 
-	public void run() {
-		// 강사 관리 메뉴에서 사용자가 뒤로 가기를 선택할 때까지 반복한다.
-		while (true) {
-			printTitle("강사 관리");
-			System.out.println("""
-				1. 강사 등록
-				2. 강사 조회
-				3. 뒤로 가기
-				""");
+    public void run() {
+        // 강사 관리 메뉴에서 사용자가 뒤로 가기를 선택할 때까지 반복한다.
+        while (true) {
+            printTitle("강사 관리");
+            System.out.println("""
+                1. 강사 등록
+                2. 강사 조회
+                3. 뒤로 가기
+                """);
 
-			int choice = readInt("선택 > ");
-			if (choice == 1) {
-				showCreateScreen();
-			} else if (choice == 2) {
-				showListScreen();
-			} else if (choice == 3) {
-				return;
-			} else {
-				System.out.println("잘못된 메뉴입니다.");
-			}
-		}
-	}
+            int choice = readInt("선택 > ");
+            if (choice == 1) {
+                showCreateScreen();
+            } else if (choice == 2) {
+                showListScreen();
+            } else if (choice == 3) {
+                return;
+            } else {
+                System.out.println("잘못된 메뉴입니다.");
+            }
+        }
+    }
 
-	private void showCreateScreen() {
-		while (true) {
-			printTitle("강사 등록");
+    private void showCreateScreen() {
+        while (true) {
+            printTitle("강사 등록");
 
-			String name = readLine("이름 > ");
-			String introduction = readLine("소개 > ");
+            String name = readLine("이름 > ");
+            String introduction = readLine("소개 > ");
 
-			try {
-				Long instructorId = instructorController.createInstructor(
-					new InstructorCreateRequest(name, introduction)
-				);
-				System.out.println("강사가 등록되었습니다. id: " + instructorId);
-			} catch (IllegalArgumentException exception) {
-				// 도메인 검증 실패 메시지는 그대로 사용자에게 보여 준다.
-				System.out.println(exception.getMessage());
-				continue;
-			}
+            try {
+                Long instructorId = instructorController.createInstructor(
+                    new InstructorCreateRequest(name, introduction)
+                );
+                System.out.println("강사가 등록되었습니다. id: " + instructorId);
+            } catch (LxpException exception) {
+                // 업무 예외는 메시지만 출력하고 현재 화면에서 다시 입력받는다.
+                System.out.println(exception.getMessage());
+                continue;
+            }
 
-			System.out.println();
-			System.out.println("""
-				1. 강사 등록
-				2. 강사 조회
-				""");
-			int choice = readInt("선택 > ");
-			if (choice == 1) {
-				continue;
-			}
-			if (choice == 2) {
-				showListScreen();
-			} else {
-				System.out.println("잘못된 메뉴입니다.");
-				continue;
-			}
-			return;
-		}
-	}
+            System.out.println();
+            System.out.println("""
+                1. 강사 등록
+                2. 강사 조회
+                """);
+            int choice = readInt("선택 > ");
+            if (choice == 1) {
+                continue;
+            }
+            if (choice == 2) {
+                showListScreen();
+            } else {
+                System.out.println("잘못된 메뉴입니다.");
+                continue;
+            }
+            return;
+        }
+    }
 
-	private void showListScreen() {
-		while (true) {
-			printTitle("강사 목록");
-			// 목록은 항상 최신 상태를 보이도록 화면 진입 시마다 다시 조회한다.
-			List<Instructor> instructors = instructorController.getInstructors();
+    private void showListScreen() {
+        while (true) {
+            printTitle("강사 목록");
+            // 목록은 항상 최신 상태를 보여주기 위해 화면 진입 시마다 다시 조회한다.
+            List<Instructor> instructors = instructorController.getInstructors();
 
-			if (instructors.isEmpty()) {
-				System.out.println("등록된 강사가 없습니다.");
-			} else {
-				for (Instructor instructor : instructors) {
-					System.out.println(instructor.getId() + ". " + instructor.getName());
-				}
-			}
+            if (instructors.isEmpty()) {
+                System.out.println("등록된 강사가 없습니다.");
+            } else {
+                for (Instructor instructor : instructors) {
+                    System.out.println(instructor.getId() + ". " + instructor.getName());
+                }
+            }
 
-			System.out.println();
-			System.out.println("""
-				1. 강사 선택
-				2. 뒤로 가기
-				""");
+            System.out.println();
+            System.out.println("""
+                1. 강사 선택
+                2. 뒤로 가기
+                """);
 
-			int choice = readInt("선택 > ");
-			if (choice == 1) {
-				Long instructorId = readLong("강사 ID > ");
-				showDetailScreen(instructorId);
-			} else if (choice == 2) {
-				return;
-			} else {
-				System.out.println("잘못된 메뉴입니다.");
-			}
-		}
-	}
+            int choice = readInt("선택 > ");
+            if (choice == 1) {
+                Long instructorId = readLong("강사 ID > ");
+                showDetailScreen(instructorId);
+            } else if (choice == 2) {
+                return;
+            } else {
+                System.out.println("잘못된 메뉴입니다.");
+            }
+        }
+    }
 
-	private void showDetailScreen(Long instructorId) {
-		while (true) {
-			Instructor instructor;
+    private void showDetailScreen(Long instructorId) {
+        while (true) {
+            Instructor instructor;
 
-			// 조회 대상이 없으면 상세 화면에 머무르지 않고 목록으로 돌아간다.
-			try {
-				instructor = instructorController.getInstructor(instructorId);
-			} catch (IllegalArgumentException exception) {
-				System.out.println("존재하지 않는 강사입니다.");
-				return;
-			}
+            // 조회 대상이 없으면 상세 화면에 머무르지 않고 목록으로 돌아간다.
+            try {
+                instructor = instructorController.getInstructor(instructorId);
+            } catch (LxpException exception) {
+                System.out.println(exception.getMessage());
+                return;
+            }
 
-			printTitle("강사 상세");
-			System.out.println("강사 id: " + instructor.getId());
-			System.out.println("이름: " + instructor.getName());
-			System.out.println("소개: " + instructor.getIntroduction());
-			System.out.println();
-			System.out.println("""
-				1. 강사 수정
-				2. 강사 삭제
-				3. 뒤로 가기
-				""");
+            printTitle("강사 상세");
+            System.out.println("강사 id: " + instructor.getId());
+            System.out.println("이름: " + instructor.getName());
+            System.out.println("소개: " + instructor.getIntroduction());
+            System.out.println();
+            System.out.println("""
+                1. 강사 수정
+                2. 강사 삭제
+                3. 뒤로 가기
+                """);
 
-			int choice = readInt("선택 > ");
-			if (choice == 1) {
-				showUpdateScreen(instructor);
-			} else if (choice == 2) {
-				// 강사에 연결된 강의가 있으면 삭제할 수 없으므로 안내만 하고 화면을 유지한다.
-				try {
-					instructorController.deleteInstructor(instructorId);
-					System.out.println("삭제가 완료되었습니다. id: " + instructorId);
-					return;
-				} catch (IllegalStateException exception) {
-					System.out.println(exception.getMessage());
-				}
-			} else if (choice == 3) {
-				return;
-			} else {
-				System.out.println("잘못된 메뉴입니다.");
-			}
-		}
-	}
+            int choice = readInt("선택 > ");
+            if (choice == 1) {
+                showUpdateScreen(instructor);
+            } else if (choice == 2) {
+                try {
+                    instructorController.deleteInstructor(instructorId);
+                    System.out.println("삭제가 완료되었습니다. id: " + instructorId);
+                    return;
+                } catch (LxpException exception) {
+                    System.out.println(exception.getMessage());
+                }
+            } else if (choice == 3) {
+                return;
+            } else {
+                System.out.println("잘못된 메뉴입니다.");
+            }
+        }
+    }
 
-	private void showUpdateScreen(Instructor currentInstructor) {
-		Instructor instructor = currentInstructor;
-		while (true) {
-			printTitle("강사 수정");
-			System.out.println("빈 값 입력 시 기존 값이 유지됩니다.");
-			String name = readLine("이름(" + instructor.getName() + ") > ");
-			String introduction = readLine("소개(" + instructor.getIntroduction() + ") > ");
+    private void showUpdateScreen(Instructor currentInstructor) {
+        Instructor instructor = currentInstructor;
+        while (true) {
+            printTitle("강사 수정");
+            System.out.println("빈 값을 입력하면 기존 값이 유지됩니다.");
+            String name = readLine("이름(" + instructor.getName() + ") > ");
+            String introduction = readLine("소개(" + instructor.getIntroduction() + ") > ");
 
-			// 공백 입력은 기존 값을 유지하도록 서비스 계층에서 해석한다.
-			try {
-				instructor = instructorController.updateInstructor(
-					instructor.getId(),
-					new InstructorUpdateRequest(name, introduction)
-				);
-				System.out.println("수정되었습니다.");
-				System.out.println("강사 id: " + instructor.getId());
-				System.out.println("이름: " + instructor.getName());
-				System.out.println("소개: " + instructor.getIntroduction());
-			} catch (IllegalArgumentException exception) {
-				System.out.println(exception.getMessage());
-				continue;
-			}
+            // 공백 입력은 서비스 계층에서 기존 값 유지 규칙으로 해석한다.
+            try {
+                instructor = instructorController.updateInstructor(
+                    instructor.getId(),
+                    new InstructorUpdateRequest(name, introduction)
+                );
+                System.out.println("수정되었습니다.");
+                System.out.println("강사 id: " + instructor.getId());
+                System.out.println("이름: " + instructor.getName());
+                System.out.println("소개: " + instructor.getIntroduction());
+            } catch (LxpException exception) {
+                System.out.println(exception.getMessage());
+                continue;
+            }
 
-			System.out.println();
-			System.out.println("""
-				1. 강사 수정
-				2. 강사 삭제
-				3. 뒤로 가기
-				""");
+            System.out.println();
+            System.out.println("""
+                1. 강사 수정
+                2. 강사 삭제
+                3. 뒤로 가기
+                """);
 
-			int choice = readInt("선택 > ");
-			if (choice == 1) {
-				continue;
-			}
-			if (choice == 2) {
-				// 삭제 조건을 만족하지 않으면 수정 화면에서 바로 재시도할 수 있게 유지한다.
-				try {
-					instructorController.deleteInstructor(instructor.getId());
-					System.out.println("삭제가 완료되었습니다. id: " + instructor.getId());
-				} catch (IllegalStateException exception) {
-					System.out.println(exception.getMessage());
-					continue;
-				}
-			}
-			return;
-		}
-	}
+            int choice = readInt("선택 > ");
+            if (choice == 1) {
+                continue;
+            }
+            if (choice == 2) {
+                try {
+                    instructorController.deleteInstructor(instructor.getId());
+                    System.out.println("삭제가 완료되었습니다. id: " + instructor.getId());
+                } catch (LxpException exception) {
+                    System.out.println(exception.getMessage());
+                    continue;
+                }
+            }
+            return;
+        }
+    }
 
-	private void printTitle(String title) {
-		System.out.println();
-		System.out.println("==============================");
-		System.out.println(title);
-		System.out.println("==============================");
-	}
+    private void printTitle(String title) {
+        System.out.println();
+        System.out.println("==============================");
+        System.out.println(title);
+        System.out.println("==============================");
+    }
 
-	private int readInt(String prompt) {
-		while (true) {
-			String value = readLine(prompt);
-			try {
-				return Integer.parseInt(value);
-			} catch (NumberFormatException exception) {
-				System.out.println("숫자를 입력해주세요.");
-			}
-		}
-	}
+    private int readInt(String prompt) {
+        while (true) {
+            String value = readLine(prompt);
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException exception) {
+                System.out.println("숫자를 입력해주세요.");
+            }
+        }
+    }
 
-	private Long readLong(String prompt) {
-		while (true) {
-			String value = readLine(prompt);
-			try {
-				return Long.parseLong(value);
-			} catch (NumberFormatException exception) {
-				System.out.println("숫자를 입력해주세요.");
-			}
-		}
-	}
+    private Long readLong(String prompt) {
+        while (true) {
+            String value = readLine(prompt);
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException exception) {
+                System.out.println("숫자를 입력해주세요.");
+            }
+        }
+    }
 
-	private String readLine(String prompt) {
-		System.out.print(prompt);
-		return scanner.nextLine().trim();
-	}
+    private String readLine(String prompt) {
+        System.out.print(prompt);
+        return scanner.nextLine().trim();
+    }
 }

--- a/src/main/java/com/potenup/lxp/instructor/domain/Instructor.java
+++ b/src/main/java/com/potenup/lxp/instructor/domain/Instructor.java
@@ -1,5 +1,7 @@
 package com.potenup.lxp.instructor.domain;
 
+import com.potenup.lxp.common.exception.ValidationException;
+
 // 강사 도메인 객체로, 생성 시점에 기본 유효성 검증을 함께 수행한다.
 public class Instructor {
 	private static final int MAX_NAME_LENGTH = 10;
@@ -42,17 +44,17 @@ public class Instructor {
 	private void validateId(Long id) {
 		// DB 식별자는 1 이상의 값만 유효하다고 본다.
 		if (id == null || id <= 0) {
-			throw new IllegalArgumentException("Instructor id must be greater than zero.");
+			throw new ValidationException("Instructor id must be greater than zero.");
 		}
 	}
 
 	private void validateName(String name) {
 		// 이름은 비어 있을 수 없고 화면 정책에 맞는 최대 길이를 넘으면 안 된다.
 		if (name == null || name.isBlank()) {
-			throw new IllegalArgumentException("Instructor name is required.");
+			throw new ValidationException("Instructor name is required.");
 		}
 		if (name.length() > MAX_NAME_LENGTH) {
-			throw new IllegalArgumentException(
+			throw new ValidationException(
 					"Instructor name must be " + MAX_NAME_LENGTH + " characters or less."
 			);
 		}
@@ -61,10 +63,10 @@ public class Instructor {
 	private void validateIntroduction(String introduction) {
 		// 소개도 필수 값이며 저장 전에 길이를 제한한다.
 		if (introduction == null || introduction.isBlank()) {
-			throw new IllegalArgumentException("Instructor introduction is required.");
+			throw new ValidationException("Instructor introduction is required.");
 		}
 		if (introduction.length() > MAX_INTRODUCTION_LENGTH) {
-			throw new IllegalArgumentException(
+			throw new ValidationException(
 					"Instructor introduction must be " + MAX_INTRODUCTION_LENGTH + " characters or less."
 			);
 		}

--- a/src/main/java/com/potenup/lxp/instructor/repository/JdbcInstructorRepository.java
+++ b/src/main/java/com/potenup/lxp/instructor/repository/JdbcInstructorRepository.java
@@ -1,5 +1,7 @@
 package com.potenup.lxp.instructor.repository;
 
+import com.potenup.lxp.common.exception.DataAccessException;
+import com.potenup.lxp.common.exception.NotFoundException;
 import com.potenup.lxp.common.jdbc.JdbcConnectionManager;
 import com.potenup.lxp.common.query.QueryRegistry;
 import com.potenup.lxp.instructor.domain.Instructor;
@@ -15,123 +17,125 @@ import java.util.Optional;
 
 // JDBC를 사용해 instructor 테이블에 접근하는 저장소 구현체다.
 public class JdbcInstructorRepository implements InstructorRepository {
-	private final JdbcConnectionManager connectionManager;
-	private final QueryRegistry queryRegistry;
+    private final JdbcConnectionManager connectionManager;
+    private final QueryRegistry queryRegistry;
 
-	public JdbcInstructorRepository(JdbcConnectionManager connectionManager, QueryRegistry queryRegistry) {
-		this.connectionManager = connectionManager;
-		this.queryRegistry = queryRegistry;
-	}
+    public JdbcInstructorRepository(JdbcConnectionManager connectionManager, QueryRegistry queryRegistry) {
+        this.connectionManager = connectionManager;
+        this.queryRegistry = queryRegistry;
+    }
 
-	@Override
-	public Long save(Instructor instructor) {
-		try (Connection connection = connectionManager.getConnection();
-		     PreparedStatement statement = connection.prepareStatement(
-				 queryRegistry.get("instructor.insert"),
-				 Statement.RETURN_GENERATED_KEYS
-			 )) {
-			// 도메인 객체 값을 PreparedStatement에 바인딩해서 SQL 인젝션을 피한다.
-			statement.setString(1, instructor.getName());
-			statement.setString(2, instructor.getIntroduction());
-			statement.executeUpdate();
+    @Override
+    public Long save(Instructor instructor) {
+        try (Connection connection = connectionManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(
+                 queryRegistry.get("instructor.insert"),
+                 Statement.RETURN_GENERATED_KEYS
+             )) {
+            // 도메인 객체 값을 PreparedStatement에 바인딩해 SQL 인젝션을 방지한다.
+            statement.setString(1, instructor.getName());
+            statement.setString(2, instructor.getIntroduction());
+            statement.executeUpdate();
 
-			try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
-				if (generatedKeys.next()) {
-					return generatedKeys.getLong(1);
-				}
-			}
-			throw new IllegalStateException("Failed to retrieve generated instructor id.");
-		} catch (SQLException exception) {
-			throw new IllegalStateException("Failed to save instructor.", exception);
-		}
-	}
+            try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    return generatedKeys.getLong(1);
+                }
+            }
+            throw new DataAccessException("Failed to retrieve generated instructor id.");
+        } catch (SQLException exception) {
+            throw new DataAccessException("Failed to save instructor.", exception);
+        }
+    }
 
-	@Override
-	public boolean existsById(Long instructorId) {
-		try (Connection connection = connectionManager.getConnection();
-		     PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.existsById"))) {
-			statement.setLong(1, instructorId);
+    @Override
+    public boolean existsById(Long instructorId) {
+        try (Connection connection = connectionManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.existsById"))) {
+            statement.setLong(1, instructorId);
 
-			try (ResultSet resultSet = statement.executeQuery()) {
-				// 존재 여부만 필요하므로 첫 행이 있는지만 확인한다.
-				return resultSet.next();
-			}
-		} catch (SQLException exception) {
-			throw new IllegalStateException("Failed to check instructor existence.", exception);
-		}
-	}
+            try (ResultSet resultSet = statement.executeQuery()) {
+                // 존재 여부만 필요하므로 첫 행이 있는지만 확인한다.
+                return resultSet.next();
+            }
+        } catch (SQLException exception) {
+            throw new DataAccessException("Failed to check instructor existence.", exception);
+        }
+    }
 
-	@Override
-	public List<Instructor> findAll() {
-		try (Connection connection = connectionManager.getConnection();
-		     PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.findAll"));
-		     ResultSet resultSet = statement.executeQuery()) {
-			List<Instructor> instructors = new ArrayList<>();
-			while (resultSet.next()) {
-				// ResultSet 한 행을 도메인 객체로 변환해 목록에 담는다.
-				instructors.add(mapInstructor(resultSet));
-			}
-			return instructors;
-		} catch (SQLException exception) {
-			throw new IllegalStateException("Failed to load instructors.", exception);
-		}
-	}
+    @Override
+    public List<Instructor> findAll() {
+        try (Connection connection = connectionManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.findAll"));
+             ResultSet resultSet = statement.executeQuery()) {
+            List<Instructor> instructors = new ArrayList<>();
+            while (resultSet.next()) {
+                // ResultSet 한 행을 도메인 객체로 변환해 목록에 담는다.
+                instructors.add(mapInstructor(resultSet));
+            }
+            return instructors;
+        } catch (SQLException exception) {
+            throw new DataAccessException("Failed to load instructors.", exception);
+        }
+    }
 
-	@Override
-	public Optional<Instructor> findById(Long instructorId) {
-		try (Connection connection = connectionManager.getConnection();
-		     PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.findById"))) {
-			statement.setLong(1, instructorId);
+    @Override
+    public Optional<Instructor> findById(Long instructorId) {
+        try (Connection connection = connectionManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.findById"))) {
+            statement.setLong(1, instructorId);
 
-			try (ResultSet resultSet = statement.executeQuery()) {
-				if (resultSet.next()) {
-					return Optional.of(mapInstructor(resultSet));
-				}
-				return Optional.empty();
-			}
-		} catch (SQLException exception) {
-			throw new IllegalStateException("Failed to load instructor.", exception);
-		}
-	}
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return Optional.of(mapInstructor(resultSet));
+                }
+                return Optional.empty();
+            }
+        } catch (SQLException exception) {
+            throw new DataAccessException("Failed to load instructor.", exception);
+        }
+    }
 
-	@Override
-	public void update(Instructor instructor) {
-		try (Connection connection = connectionManager.getConnection();
-		     PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.update"))) {
-			statement.setString(1, instructor.getName());
-			statement.setString(2, instructor.getIntroduction());
-			statement.setLong(3, instructor.getId());
-			int affectedRows = statement.executeUpdate();
-			// 수정 대상이 없으면 호출 측에서 이상 상태를 알 수 있도록 예외로 처리한다.
-			if (affectedRows == 0) {
-				throw new IllegalStateException("No instructor updated for id: " + instructor.getId());
-			}
-		} catch (SQLException exception) {
-			throw new IllegalStateException("Failed to update instructor.", exception);
-		}
-	}
+    @Override
+    public void update(Instructor instructor) {
+        try (Connection connection = connectionManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.update"))) {
+            statement.setString(1, instructor.getName());
+            statement.setString(2, instructor.getIntroduction());
+            statement.setLong(3, instructor.getId());
 
-	@Override
-	public void deleteById(Long instructorId) {
-		try (Connection connection = connectionManager.getConnection();
-		     PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.deleteById"))) {
-			statement.setLong(1, instructorId);
-			int affectedRows = statement.executeUpdate();
-			// 이미 삭제되었거나 없는 id라면 0건 반영되므로 실패로 본다.
-			if (affectedRows == 0) {
-				throw new IllegalStateException("No instructor deleted for id: " + instructorId);
-			}
-		} catch (SQLException exception) {
-			throw new IllegalStateException("Failed to delete instructor.", exception);
-		}
-	}
+            int affectedRows = statement.executeUpdate();
+            // 수정 대상이 없으면 상위 계층에서 대상 없음으로 처리할 수 있게 예외를 분리한다.
+            if (affectedRows == 0) {
+                throw new NotFoundException("No instructor updated for id: " + instructor.getId());
+            }
+        } catch (SQLException exception) {
+            throw new DataAccessException("Failed to update instructor.", exception);
+        }
+    }
 
-	private Instructor mapInstructor(ResultSet resultSet) throws SQLException {
-		// JDBC 결과를 도메인 규칙을 가진 Instructor 객체로 복원한다.
-		return new Instructor(
-			resultSet.getLong("id"),
-			resultSet.getString("name"),
-			resultSet.getString("introduction")
-		);
-	}
+    @Override
+    public void deleteById(Long instructorId) {
+        try (Connection connection = connectionManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(queryRegistry.get("instructor.deleteById"))) {
+            statement.setLong(1, instructorId);
+
+            int affectedRows = statement.executeUpdate();
+            // 이미 삭제됐거나 존재하지 않는 id면 대상 없음으로 본다.
+            if (affectedRows == 0) {
+                throw new NotFoundException("No instructor deleted for id: " + instructorId);
+            }
+        } catch (SQLException exception) {
+            throw new DataAccessException("Failed to delete instructor.", exception);
+        }
+    }
+
+    private Instructor mapInstructor(ResultSet resultSet) throws SQLException {
+        // JDBC 결과를 Instructor 도메인 객체로 복원한다.
+        return new Instructor(
+            resultSet.getLong("id"),
+            resultSet.getString("name"),
+            resultSet.getString("introduction")
+        );
+    }
 }

--- a/src/main/java/com/potenup/lxp/instructor/service/InstructorService.java
+++ b/src/main/java/com/potenup/lxp/instructor/service/InstructorService.java
@@ -1,5 +1,7 @@
 package com.potenup.lxp.instructor.service;
 
+import com.potenup.lxp.common.exception.ConstraintViolationException;
+import com.potenup.lxp.common.exception.NotFoundException;
 import com.potenup.lxp.course.repository.CourseRepository;
 import com.potenup.lxp.instructor.domain.Instructor;
 import com.potenup.lxp.instructor.dto.InstructorCreateRequest;
@@ -10,60 +12,60 @@ import java.util.List;
 
 // 강사 관련 비즈니스 규칙을 처리하는 서비스다.
 public class InstructorService {
-	private final InstructorRepository instructorRepository;
-	private final CourseRepository courseRepository;
+    private final InstructorRepository instructorRepository;
+    private final CourseRepository courseRepository;
 
-	public InstructorService(InstructorRepository instructorRepository, CourseRepository courseRepository) {
-		this.instructorRepository = instructorRepository;
-		this.courseRepository = courseRepository;
-	}
+    public InstructorService(InstructorRepository instructorRepository, CourseRepository courseRepository) {
+        this.instructorRepository = instructorRepository;
+        this.courseRepository = courseRepository;
+    }
 
-	public Long createInstructor(InstructorCreateRequest request) {
-		// 도메인 객체 생성 과정에서 이름과 소개에 대한 검증이 수행된다.
-		Instructor instructor = new Instructor(request.getName(), request.getIntroduction());
-		return instructorRepository.save(instructor);
-	}
+    public Long createInstructor(InstructorCreateRequest request) {
+        // 도메인 객체 생성 과정에서 이름과 소개에 대한 검증이 함께 수행된다.
+        Instructor instructor = new Instructor(request.getName(), request.getIntroduction());
+        return instructorRepository.save(instructor);
+    }
 
-	public List<Instructor> getInstructors() {
-		return instructorRepository.findAll();
-	}
+    public List<Instructor> getInstructors() {
+        return instructorRepository.findAll();
+    }
 
-	public Instructor getInstructor(Long instructorId) {
-		return instructorRepository.findById(instructorId)
-				.orElseThrow(() -> new IllegalArgumentException("강사를 찾을 수 없습니다."));
-	}
+    public Instructor getInstructor(Long instructorId) {
+        return instructorRepository.findById(instructorId)
+            .orElseThrow(() -> new NotFoundException("강사를 찾을 수 없습니다."));
+    }
 
-	public Instructor updateInstructor(Long instructorId, InstructorUpdateRequest request) {
-		// 수정은 기존 데이터를 조회한 뒤, 비어 있는 입력만 기존 값으로 보존한다.
-		Instructor currentInstructor = getInstructor(instructorId);
+    public Instructor updateInstructor(Long instructorId, InstructorUpdateRequest request) {
+        // 수정 전 기존 데이터를 조회해 비어 있는 입력은 기존 값으로 유지한다.
+        Instructor currentInstructor = getInstructor(instructorId);
 
-		String updatedName = isBlank(request.getName()) ? currentInstructor.getName() : request.getName();
-		String updatedIntroduction = isBlank(request.getIntroduction())
-				? currentInstructor.getIntroduction()
-				: request.getIntroduction();
+        String updatedName = isBlank(request.getName()) ? currentInstructor.getName() : request.getName();
+        String updatedIntroduction = isBlank(request.getIntroduction())
+            ? currentInstructor.getIntroduction()
+            : request.getIntroduction();
 
-		Instructor updatedInstructor = new Instructor(
-				currentInstructor.getId(),
-				updatedName,
-				updatedIntroduction
-		);
-		instructorRepository.update(updatedInstructor);
-		return updatedInstructor;
-	}
+        Instructor updatedInstructor = new Instructor(
+            currentInstructor.getId(),
+            updatedName,
+            updatedIntroduction
+        );
+        instructorRepository.update(updatedInstructor);
+        return updatedInstructor;
+    }
 
-	public void deleteInstructor(Long instructorId) {
-		// 삭제 전에 존재 여부와 연결된 강의 존재 여부를 순서대로 확인한다.
-		if (!instructorRepository.existsById(instructorId)) {
-			throw new IllegalArgumentException("강사를 찾을 수 없습니다.");
-		}
-		if (courseRepository.existsByInstructorId(instructorId)) {
-			throw new IllegalStateException("연결된 코스가 있어 강사를 삭제할 수 없습니다.");
-		}
-		instructorRepository.deleteById(instructorId);
-	}
+    public void deleteInstructor(Long instructorId) {
+        // 삭제 전에 대상 존재 여부와 연결된 강의 존재 여부를 순서대로 확인한다.
+        if (!instructorRepository.existsById(instructorId)) {
+            throw new NotFoundException("강사를 찾을 수 없습니다.");
+        }
+        if (courseRepository.existsByInstructorId(instructorId)) {
+            throw new ConstraintViolationException("연결된 코스가 있어 강사를 삭제할 수 없습니다.");
+        }
+        instructorRepository.deleteById(instructorId);
+    }
 
-	private boolean isBlank(String value) {
-		// 수정 요청에서는 null과 공백을 동일하게 취급해 "미입력"으로 본다.
-		return value == null || value.isBlank();
-	}
+    private boolean isBlank(String value) {
+        // 수정 요청에서는 null과 공백을 모두 미입력으로 본다.
+        return value == null || value.isBlank();
+    }
 }

--- a/src/test/java/com/potenup/lxp/course/service/CourseServiceTest.java
+++ b/src/test/java/com/potenup/lxp/course/service/CourseServiceTest.java
@@ -1,5 +1,7 @@
 package com.potenup.lxp.course.service;
 
+import com.potenup.lxp.common.exception.NotFoundException;
+import com.potenup.lxp.common.exception.ValidationException;
 import com.potenup.lxp.course.domain.Course;
 import com.potenup.lxp.course.domain.CourseLevel;
 import com.potenup.lxp.course.dto.CourseCreateRequest;
@@ -16,6 +18,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CourseServiceTest {
     @Test
@@ -23,10 +26,24 @@ class CourseServiceTest {
         CourseService courseService = new CourseService(new FakeCourseRepository(), new FakeInstructorRepository());
 
         Long courseId = courseService.createCourse(
-                new CourseCreateRequest("JDBC Basics", "Intro course", 30000, CourseLevel.LOW, 1L)
+            new CourseCreateRequest("JDBC Basics", "Intro course", 30000, CourseLevel.LOW, 1L)
         );
 
         assertEquals(1L, courseId);
+    }
+
+    @Test
+    void createCourseThrowsValidationExceptionWhenInstructorDoesNotExist() {
+        CourseService courseService = new CourseService(new FakeCourseRepository(), new FakeInstructorRepository());
+
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> courseService.createCourse(
+                new CourseCreateRequest("JDBC Basics", "Intro course", 30000, CourseLevel.LOW, 99L)
+            )
+        );
+
+        assertTrue(exception.getMessage() != null && !exception.getMessage().isBlank());
     }
 
     @Test
@@ -40,12 +57,24 @@ class CourseServiceTest {
     }
 
     @Test
+    void getCourseThrowsNotFoundExceptionWhenCourseDoesNotExist() {
+        CourseService courseService = new CourseService(new FakeCourseRepository(), new FakeInstructorRepository());
+
+        NotFoundException exception = assertThrows(
+            NotFoundException.class,
+            () -> courseService.getCourse(99L)
+        );
+
+        assertTrue(exception.getMessage() != null && !exception.getMessage().isBlank());
+    }
+
+    @Test
     void updateCourseKeepsExistingValuesWhenBlankIsProvided() {
         CourseService courseService = new CourseService(new FakeCourseRepository(), new FakeInstructorRepository());
 
         Course updatedCourse = courseService.updateCourse(
-                1L,
-                new CourseUpdateRequest("", "", null, null, null)
+            1L,
+            new CourseUpdateRequest("", "", null, null, null)
         );
 
         assertEquals("JDBC Basics", updatedCourse.getTitle());
@@ -62,20 +91,6 @@ class CourseServiceTest {
         courseService.deleteCourse(1L);
 
         assertFalse(repository.existsById(1L));
-    }
-
-    @Test
-    void createCourseFailsWhenInstructorDoesNotExist() {
-        CourseService courseService = new CourseService(new FakeCourseRepository(), new FakeInstructorRepository());
-
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> courseService.createCourse(
-                        new CourseCreateRequest("JDBC Basics", "Intro course", 30000, CourseLevel.LOW, 99L)
-                )
-        );
-
-        assertEquals("강사가 존재하지 않습니다. 강사를 먼저 등록해주세요.", exception.getMessage());
     }
 
     private static class FakeCourseRepository implements CourseRepository {
@@ -99,8 +114,8 @@ class CourseServiceTest {
         @Override
         public Optional<Course> findById(Long courseId) {
             return courses.stream()
-                    .filter(course -> course.getId().equals(courseId))
-                    .findFirst();
+                .filter(course -> course.getId().equals(courseId))
+                .findFirst();
         }
 
         @Override
@@ -114,20 +129,20 @@ class CourseServiceTest {
         }
 
         @Override
-        public void deleteById(Long courseId) {
-            courses.removeIf(course -> course.getId().equals(courseId));
+        public boolean deleteById(Long courseId) {
+            return courses.removeIf(course -> course.getId().equals(courseId));
         }
 
         @Override
         public boolean existsById(Long courseId) {
             return courses.stream()
-                    .anyMatch(course -> course.getId().equals(courseId));
+                .anyMatch(course -> course.getId().equals(courseId));
         }
 
         @Override
         public boolean existsByInstructorId(Long instructorId) {
             return courses.stream()
-                    .anyMatch(course -> course.getInstructorId().equals(instructorId));
+                .anyMatch(course -> course.getInstructorId().equals(instructorId));
         }
     }
 

--- a/src/test/java/com/potenup/lxp/instructor/service/FakeCourseRepository.java
+++ b/src/test/java/com/potenup/lxp/instructor/service/FakeCourseRepository.java
@@ -31,7 +31,8 @@ class FakeCourseRepository implements CourseRepository {
 	}
 
 	@Override
-	public void deleteById(Long courseId) {
+	public boolean deleteById(Long courseId) {
+		return false;
 	}
 
 	@Override

--- a/src/test/java/com/potenup/lxp/instructor/service/InstructorServiceTest.java
+++ b/src/test/java/com/potenup/lxp/instructor/service/InstructorServiceTest.java
@@ -1,5 +1,6 @@
 package com.potenup.lxp.instructor.service;
 
+import com.potenup.lxp.common.exception.ConstraintViolationException;
 import com.potenup.lxp.instructor.domain.Instructor;
 import com.potenup.lxp.instructor.dto.InstructorCreateRequest;
 import com.potenup.lxp.instructor.dto.InstructorUpdateRequest;
@@ -15,63 +16,63 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // InstructorService의 비즈니스 규칙을 가짜 저장소로 검증하는 테스트다.
 class InstructorServiceTest {
-	private FakeInstructorRepository instructorRepository;
-	private FakeCourseRepository courseRepository;
-	private InstructorService instructorService;
+    private FakeInstructorRepository instructorRepository;
+    private FakeCourseRepository courseRepository;
+    private InstructorService instructorService;
 
-	@BeforeEach
-	void setUp() {
-		// 각 테스트가 서로 영향을 주지 않도록 매번 새로운 가짜 저장소와 서비스를 만든다.
-		instructorRepository = new FakeInstructorRepository();
-		courseRepository = new FakeCourseRepository();
-		instructorService = new InstructorService(instructorRepository, courseRepository);
-	}
+    @BeforeEach
+    void setUp() {
+        // 각 테스트가 서로 영향을 주지 않도록 매번 새로운 가짜 저장소와 서비스를 만든다.
+        instructorRepository = new FakeInstructorRepository();
+        courseRepository = new FakeCourseRepository();
+        instructorService = new InstructorService(instructorRepository, courseRepository);
+    }
 
-	@Test
-	void createInstructorReturnsSavedId() {
-		Long instructorId = instructorService.createInstructor(
-			new InstructorCreateRequest("Kim", "Java and DB instructor")
-		);
+    @Test
+    void createInstructorReturnsSavedId() {
+        Long instructorId = instructorService.createInstructor(
+            new InstructorCreateRequest("Kim", "Java and DB instructor")
+        );
 
-		assertEquals(1L, instructorId);
-	}
+        assertEquals(1L, instructorId);
+    }
 
-	@Test
-	void getInstructorsReturnsAllInstructors() {
-		// 서비스가 저장소의 강사 목록을 그대로 반환하는지 확인한다.
-		List<Instructor> instructors = instructorService.getInstructors();
+    @Test
+    void getInstructorsReturnsAllInstructors() {
+        // 서비스가 저장소의 강사 목록을 그대로 반환하는지 확인한다.
+        List<Instructor> instructors = instructorService.getInstructors();
 
-		assertEquals(2, instructors.size());
-		assertEquals("Kim", instructors.get(0).getName());
-	}
+        assertEquals(2, instructors.size());
+        assertEquals("Kim", instructors.get(0).getName());
+    }
 
-	@Test
-	void updateInstructorKeepsExistingValuesWhenBlankIsProvided() {
-		// 빈 문자열을 넘기면 기존 값이 유지되는 수정 규칙을 검증한다.
-		Instructor updatedInstructor = instructorService.updateInstructor(1L, new InstructorUpdateRequest("", ""));
+    @Test
+    void updateInstructorKeepsExistingValuesWhenBlankIsProvided() {
+        // 빈 문자열이면 기존 값이 유지되는 수정 규칙을 검증한다.
+        Instructor updatedInstructor = instructorService.updateInstructor(1L, new InstructorUpdateRequest("", ""));
 
-		assertEquals("Kim", updatedInstructor.getName());
-		assertEquals("Java and DB instructor", updatedInstructor.getIntroduction());
-	}
+        assertEquals("Kim", updatedInstructor.getName());
+        assertEquals("Java and DB instructor", updatedInstructor.getIntroduction());
+    }
 
-	@Test
-	void deleteInstructorRemovesInstructor() {
-		instructorService.deleteInstructor(1L);
+    @Test
+    void deleteInstructorRemovesInstructor() {
+        instructorService.deleteInstructor(1L);
 
-		assertFalse(instructorRepository.existsById(1L));
-	}
+        assertFalse(instructorRepository.existsById(1L));
+    }
 
-	@Test
-	void deleteInstructorFailsWhenAssignedCourseExists() {
-		// 삭제 실패 시나리오를 만들기 위해 1번 강사에 연결된 강의가 있다고 가정한다.
-		courseRepository.assignInstructor(1L);
+    @Test
+    void deleteInstructorFailsWhenAssignedCourseExists() {
+        // 삭제 실패 시나리오를 만들기 위해 1번 강사에 연결된 강의가 있다고 가정한다.
+        courseRepository.assignInstructor(1L);
 
-		IllegalStateException exception = assertThrows(
-				IllegalStateException.class,
-				() -> instructorService.deleteInstructor(1L)
-		);
+        ConstraintViolationException exception = assertThrows(
+            ConstraintViolationException.class,
+            () -> instructorService.deleteInstructor(1L)
+        );
 
-		assertTrue(exception.getMessage() != null && !exception.getMessage().isBlank());
-		assertFalse(instructorRepository.findById(1L).isEmpty());
-	}
+        assertTrue(exception.getMessage() != null && !exception.getMessage().isBlank());
+        assertFalse(instructorRepository.findById(1L).isEmpty());
+    }
 }

--- a/src/test/java/com/potenup/lxp/instructor/service/InstructorServiceTest.java
+++ b/src/test/java/com/potenup/lxp/instructor/service/InstructorServiceTest.java
@@ -1,6 +1,8 @@
 package com.potenup.lxp.instructor.service;
 
 import com.potenup.lxp.common.exception.ConstraintViolationException;
+import com.potenup.lxp.common.exception.NotFoundException;
+import com.potenup.lxp.common.exception.ValidationException;
 import com.potenup.lxp.instructor.domain.Instructor;
 import com.potenup.lxp.instructor.dto.InstructorCreateRequest;
 import com.potenup.lxp.instructor.dto.InstructorUpdateRequest;
@@ -38,12 +40,32 @@ class InstructorServiceTest {
     }
 
     @Test
+    void createInstructorThrowsValidationExceptionWhenNameIsBlank() {
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> instructorService.createInstructor(new InstructorCreateRequest("", "Java and DB instructor"))
+        );
+
+        assertTrue(exception.getMessage() != null && !exception.getMessage().isBlank());
+    }
+
+    @Test
     void getInstructorsReturnsAllInstructors() {
         // 서비스가 저장소의 강사 목록을 그대로 반환하는지 확인한다.
         List<Instructor> instructors = instructorService.getInstructors();
 
         assertEquals(2, instructors.size());
         assertEquals("Kim", instructors.get(0).getName());
+    }
+
+    @Test
+    void getInstructorThrowsNotFoundExceptionWhenInstructorDoesNotExist() {
+        NotFoundException exception = assertThrows(
+            NotFoundException.class,
+            () -> instructorService.getInstructor(99L)
+        );
+
+        assertTrue(exception.getMessage() != null && !exception.getMessage().isBlank());
     }
 
     @Test


### PR DESCRIPTION
- Closes #6


## 📌 개요
- 공통 예외 계층을 도입하고 `instructor`, `course` 패키지에 도메인 전용 예외 처리 패턴을 적용했습니다.
- 서비스, JDBC 저장소, CLI가 `IllegalArgumentException`/`IllegalStateException` 대신 의미가 드러나는 예외를 사용하도록 정리했습니다.

## ✅ 변경 사항
- `common.exception` 패키지에 `LxpException` 기반 공통 예외 계층을 추가했습니다.
- `instructor` 패키지에 `ValidationException`, `NotFoundException`, `ConstraintViolationException`, `DataAccessException` 패턴을 적용했습니다.
- `InstructorCliHandler`에서 `LxpException` 하나로 공통 예외를 처리하도록 정리했습니다.
- `course` 패키지에도 동일한 예외 처리 패턴을 확장 적용했습니다.
- `InstructorServiceTest`, `CourseServiceTest`에 새 예외 계층 기준 테스트를 추가했습니다.

## 🤔 변경 이유(선택)
- 계층마다 흩어진 기본 예외 사용으로 인해 CLI에서 예외 처리 로직이 중복되고 일부 경로는 누락되고 있었습니다.
- 공통 베이스 예외를 두고 의미별 예외 타입으로 분리하면 서비스 의도가 더 잘 드러나고, CLI에서도 일관되게 처리할 수 있습니다.

## 🧪 테스트
- [x] 로컬 테스트 완료

실행한 테스트
- `.\gradlew.bat compileJava --rerun-tasks`
- `.\gradlew.bat test --tests com.potenup.lxp.instructor.service.InstructorServiceTest --rerun-tasks`
- `.\gradlew.bat test --tests com.potenup.lxp.course.service.CourseServiceTest --rerun-tasks`

## 🧩 고민한 부분(선택)
- `deleteById`는 `instructor`는 예외 기반, `course`는 기존 계약을 유지해 boolean 반환 기반으로 남아 있어 이번 변경에서는 서비스 계약을 보존하는 쪽을 우선했습니다.
- 테스트 더블은 일부 중복이 있지만, 현재는 테스트 의존 범위가 달라 전역 공용 fake로 합치지 않고 유지했습니다.

## 📷 스크린샷 (선택)

## ✅ 체크리스트
- [x] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [ ] 문서 업데이트 (필요 시)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 작업 실패 시 더 구체적이고 일관된 오류 메시지 표시
  * 삭제/조회 실패 시 "찾을 수 없음" 처리로 UI가 중단되지 않음
  * DB 연동 오류가 사용자에게 적절히 보고되도록 개선

* **Improvements**
  * 입력 검증 강화로 유효성 오류에 대한 명확한 피드백 제공
  * CLI 텍스트: "난이도" → "레벨" 용어 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->